### PR TITLE
feat: integrate openChat tour action for GabsIA widget

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -18,6 +18,7 @@ const nextConfig = {
                     './App': './src/pages/_app.tsx',
                     './Chatbot': './src/pages/chatbot/index.tsx',
                     './GabsIAWidget': './src/components/GabsIAWidget.tsx',
+                    './tourSteps': './src/tourSteps.ts',
                 },
                 remotes: {
                     shell: `shell@${process.env.NEXT_PUBLIC_SHELL_REMOTE_URL}/_next/static/chunks/remoteEntry.js`,

--- a/src/components/GabsIAWidget.tsx
+++ b/src/components/GabsIAWidget.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "react";
+import { useGabsIA } from "@/hooks/useGabsIA";
 
 type ButtonAction = { label: string; anchorId: string };
 type BotResponse = { reply: string; actions?: ButtonAction[] };
@@ -12,7 +13,7 @@ export const GabsIAWidget = () => {
   const [contextMessage, setContextMessage] = useState<string | null>(null);
   const [userMessage, setUserMessage] = useState("");
   const [aiReply, setAiReply] = useState<string | null>(null);
-  const [loading, setLoading] = useState(false);
+  const { askGabs, loading } = useGabsIA();
   const [showInput, setShowInput] = useState(false);
   const [showInstructions, setShowInstructions] = useState(true);
   const [isDragging, setIsDragging] = useState(false);
@@ -109,25 +110,28 @@ export const GabsIAWidget = () => {
     return () => document.removeEventListener("mousedown", handleClickOutside);
   }, []);
 
+  useEffect(() => {
+    const handleOpenChat = () => {
+      setContextMessage(null);
+      setAiReply(null);
+      setShowInput(true);
+      setShowInstructions(false);
+    };
+    window.addEventListener("openChat", handleOpenChat as any);
+    return () => window.removeEventListener("openChat", handleOpenChat as any);
+  }, []);
+
   const sendQuestion = async () => {
     if (!userMessage.trim()) return;
-    setLoading(true);
     setContextMessage(null);
     setAiReply(null);
 
     try {
-      const res = await fetch("/api/gabsia", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ message: userMessage }),
-      });
-
-      const data = await res.json();
+      const data = await askGabs(userMessage);
       setAiReply(data.reply || "Sem resposta.");
     } catch (err) {
       setAiReply("Erro ao se comunicar com a IA.");
     } finally {
-      setLoading(false);
       setUserMessage("");
     }
   };

--- a/src/tourSteps.ts
+++ b/src/tourSteps.ts
@@ -1,0 +1,18 @@
+export type TourStep = {
+  target?: string;
+  content: string;
+  action?: 'openChat';
+};
+
+export const tourSteps: TourStep[] = [
+  {
+    target: '.gabs-avatar',
+    content: 'Clique no assistente para interagir com o portfólio.'
+  },
+  {
+    content: 'Agora você pode conversar com o Gabs.IA.',
+    action: 'openChat'
+  }
+];
+
+export default tourSteps;


### PR DESCRIPTION
## Summary
- expose `tourSteps` including final `openChat` action
- wire `GabsIAWidget` to open chat when tour triggers `openChat`
- leverage `askGabs` hook for post-tour questions

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689778dab7c08333b411b6ef4ba7ce7c