### PR TITLE
feat: integrate shell chat store for persistent conversation

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -22,6 +22,7 @@ const nextConfig = {
                 },
                 remotes: {
                     shell: `shell@${process.env.NEXT_PUBLIC_SHELL_REMOTE_URL}/_next/static/chunks/remoteEntry.js`,
+                    'chat-store': `chat-store@${process.env.NEXT_PUBLIC_SHELL_REMOTE_URL}/_next/static/chunks/remoteEntry.js`,
                 },
                 shared: {
                     react: {

--- a/src/components/GabsIAWidget.tsx
+++ b/src/components/GabsIAWidget.tsx
@@ -3,6 +3,7 @@ import OverlayHighlighter from "./OverlayHighlighter";
 import { useGabsIA } from "@/hooks/useGabsIA";
 import { DotLottieReact } from "@lottiefiles/dotlottie-react";
 import guidedSteps from "@/tourSteps";
+import { useChatStore } from "chat-store";
 
 export const TYPES_VERSION = "1.0.0";
 
@@ -58,13 +59,13 @@ export const GabsIAWidget = ({
   fixedPosition,
 }: GabsIAWidgetProps) => {
   const { askGabs, loading, responses } = useGabsIA();
+  const { conversationId, messages, start, append, hydrate } = useChatStore();
   const [tourIndex, setTourIndex] = useState(0);
   const [tourActive, setTourActive] = useState(false);
   const [tourSkipped, setTourSkipped] = useState(false);
   const [disabled, setDisabled] = useState(false);
   const [contextMessage, setContextMessage] = useState<string | null>(null);
   const [userMessage, setUserMessage] = useState("");
-  const [aiReply, setAiReply] = useState<string | null>(null);
   const [showInput, setShowInput] = useState(false);
   const [isDragging, setIsDragging] = useState(false);
   const [reduceMotion, setReduceMotion] = useState(false);
@@ -90,6 +91,14 @@ export const GabsIAWidget = ({
   }));
 
   useEffect(() => {
+    if (typeof window === "undefined") return;
+    if (!conversationId) {
+      const cid = new URLSearchParams(window.location.search).get("cid");
+      cid ? hydrate(cid) : start();
+    }
+  }, [conversationId, start, hydrate]);
+
+  useEffect(() => {
     const saved = localStorage.getItem(localStorageKey);
     if (saved === "true") setDisabled(true);
     const skipped = localStorage.getItem(tourStorageKey);
@@ -113,7 +122,6 @@ export const GabsIAWidget = ({
       if (id && responses[id]) {
         highlightElement(el as HTMLElement);
         setContextMessage(responses[id].reply);
-        setAiReply(null);
         setShowInput(false);
       }
     };
@@ -153,7 +161,6 @@ export const GabsIAWidget = ({
       }
     }
     setContextMessage(step.content);
-    setAiReply(null);
     setShowInput(false);
     if (step.action === "openChat") {
       window.dispatchEvent(new Event("openChat"));
@@ -353,7 +360,6 @@ export const GabsIAWidget = ({
   useEffect(() => {
     const handleOpenChat = () => {
       setContextMessage(null);
-      setAiReply(null);
       setShowInput(true);
     };
     window.addEventListener("openChat", handleOpenChat as any);
@@ -402,15 +408,15 @@ export const GabsIAWidget = ({
 
   const sendQuestion = async () => {
     if (!userMessage.trim()) return;
+    const text = userMessage;
+    setUserMessage("");
     setContextMessage(null);
-    setAiReply(null);
+    append({ role: "user", text });
     try {
-      const data = await askGabs(userMessage);
-      setAiReply(data.reply || "Sem resposta.");
+      const data = await askGabs(text, conversationId);
+      append({ role: "assistant", text: data.reply || "Sem resposta." });
     } catch {
-      setAiReply("Erro ao se comunicar com a IA.");
-    } finally {
-      setUserMessage("");
+      append({ role: "assistant", text: "Erro ao se comunicar com a IA." });
     }
   };
 
@@ -437,7 +443,7 @@ export const GabsIAWidget = ({
     >
       {!disabled && <OverlayHighlighter target={highlightTarget} />}
 
-      {(contextMessage || aiReply || showInput) && !disabled && (
+      {(contextMessage || messages.length > 0 || showInput) && !disabled && (
         <div
           style={{
             maxWidth: isMobile ? "92vw" : 300,
@@ -489,12 +495,11 @@ export const GabsIAWidget = ({
             </div>
             <button
               onClick={() => {
-                try {
+              try {
                   localStorage.setItem(localStorageKey, "true");
                 } catch {}
                 setDisabled(true);
                 setContextMessage(null);
-                setAiReply(null);
                 setShowInput(false);
                 setHighlightTarget(null);
               }}
@@ -515,7 +520,9 @@ export const GabsIAWidget = ({
 
           {loading && <p>Gerando resposta...</p>}
           {contextMessage && <p>{contextMessage}</p>}
-          {aiReply && <p>{aiReply}</p>}
+          {messages.map((m, i) => (
+            <p key={i}>{m.text}</p>
+          ))}
           {showInput && (
             <>
               <input
@@ -620,7 +627,6 @@ export const GabsIAWidget = ({
               return;
             }
             setContextMessage(null);
-            setAiReply(null);
             setShowInput(true);
             setHighlightTarget(null);
             setTimeout(() => inputRef.current?.focus(), 0);
@@ -635,7 +641,6 @@ export const GabsIAWidget = ({
               const now = Date.now();
               if (now - (lastTapRef.current || 0) < 300) {
                 setContextMessage(null);
-                setAiReply(null);
                 setShowInput(true);
                 setHighlightTarget(null);
                 setTimeout(() => inputRef.current?.focus(), 0);
@@ -645,7 +650,6 @@ export const GabsIAWidget = ({
               lastTapRef.current = now;
             }
             setContextMessage(null);
-            setAiReply(null);
             setShowInput((prev) => !prev);
             setHighlightTarget(null);
           }}

--- a/src/hooks/useGabsIA.ts
+++ b/src/hooks/useGabsIA.ts
@@ -23,7 +23,10 @@ export function useGabsIA() {
     loadResponses();
   }, []);
 
-  const askGabs = async (message: string): Promise<BotResponse> => {
+  const askGabs = async (
+    message: string,
+    conversationId?: string
+  ): Promise<BotResponse> => {
     setLoading(true);
 
     const anchor = Object.keys(responses).find((key) =>
@@ -39,7 +42,7 @@ export function useGabsIA() {
       const result = await fetch(`${base}/api/gabsia`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ message }),
+        body: JSON.stringify({ conversationId, message }),
       });
 
       const data = await result.json();

--- a/src/pages/api/gabsia.ts
+++ b/src/pages/api/gabsia.ts
@@ -44,7 +44,7 @@ export default async function handler(
 
   if (req.method !== "POST") return res.status(405).end();
 
-  const { message } = req.body;
+  const { conversationId, message } = req.body;
   if (!message) return res.status(400).json({ error: "Mensagem vazia" });
 
   try {

--- a/src/types/declarations.d.ts
+++ b/src/types/declarations.d.ts
@@ -4,6 +4,16 @@
 declare module "shell/Error";
 declare module "shell/Providers";
 declare module "shell/I18nProvider";
+declare module "chat-store" {
+  type Message = { role: "user" | "assistant"; text: string };
+  export function useChatStore(): {
+    conversationId: string;
+    messages: Message[];
+    start: () => void;
+    append: (m: Message) => void;
+    hydrate: (id: string) => void;
+  };
+}
 
 // ───────────────────────────────────────────────
 // 🔗 Remotes: Dashboard


### PR DESCRIPTION
## Summary
- persist chat messages via shared shell store
- forward conversation id to backend and hydrate from URL
- configure remote and types for chat-store

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6898fde30e5c83339be5e1702ded8fba